### PR TITLE
Fix/1.1.x/soc 2654

### DIFF
--- a/packaging/pkg/pom.xml
+++ b/packaging/pkg/pom.xml
@@ -196,7 +196,7 @@
 
     <dependency>
       <groupId>org.gatein.wci</groupId>
-      <artifactId>wci-tomcat</artifactId>
+      <artifactId>wci-tomcat6</artifactId>
       <version>${org.gatein.wci.version}</version>
       <type>jar</type>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <org.exoplatform.tool.version>1.0.0</org.exoplatform.tool.version>
 
     <org.gatein.common.version>2.0.3-GA</org.gatein.common.version>
-    <org.gatein.wci.version>2.0.2-GA</org.gatein.wci.version>
+    <org.gatein.wci.version>2.1.0-GA</org.gatein.wci.version>
     <org.gatein.pc.version>2.2.0-GA</org.gatein.pc.version>
     <org.gatein.wsrp.version>1.1.1-GA</org.gatein.wsrp.version>
     <org.gatein.mop.version>1.0.4-GA</org.gatein.mop.version>


### PR DESCRIPTION
Updated gatein wci version to 2.1.0-GA and use wci-tomcat6 instead of wci-tomcat
