### PR TITLE
Fix/1.2.x/soc 2603

### DIFF
--- a/component/core/src/test/java/org/exoplatform/social/core/processor/MentionsProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/MentionsProcessorTest.java
@@ -32,27 +32,32 @@ import org.exoplatform.social.core.test.AbstractCoreTest;
 public class MentionsProcessorTest extends AbstractCoreTest {
 
   private IdentityManager identityManager;
-  private Identity rootIdentity, johnIdentity;
+  private Identity rootIdentity, johnIdentity, maryIdentity, demoIdentity;
 
 
   public void setUp() throws Exception {
     super.setUp();
     identityManager = (IdentityManager) PortalContainer.getComponent(IdentityManager.class);
     assertNotNull("identityManager must not be null", identityManager);
-    rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root");
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john");
+    rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", true);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", true);
+    maryIdentity = createIdentity(OrganizationIdentityProvider.NAME, "mary.kelly");
+    demoIdentity = createIdentity(OrganizationIdentityProvider.NAME, "demo_gtn");
     assertNotNull("rootIdentity.getId() must not be null", rootIdentity.getId());
     assertNotNull("johnIdentity.getId() must not be null", johnIdentity.getId());
+    assertNotNull("maryIdentity.getId() must not be null", maryIdentity.getId());
+    assertNotNull("demoIdentity.getId() must not be null", demoIdentity.getId());
   }
 
   public void tearDown() throws Exception {
     identityManager.deleteIdentity(rootIdentity);
     identityManager.deleteIdentity(johnIdentity);
+    identityManager.deleteIdentity(maryIdentity);
+    identityManager.deleteIdentity(demoIdentity);
     super.tearDown();
   }
 
   public void testSubstituteUsernames() throws Exception {
-    assertTrue(true);
     MentionsProcessor processor = (MentionsProcessor) getContainer().getComponentInstanceOfType(MentionsProcessor.class);
     assertNotNull("prococessor must not be null", processor);
     ExoSocialActivity activity = null;
@@ -64,10 +69,12 @@ public class MentionsProcessorTest extends AbstractCoreTest {
     assertNull(activity.getTitle());
     assertNull(activity.getBody());
 
-    String root = "root", john = "john";
+    String root = "root", john = "john", mary = "mary.kelly", demo = "demo_gtn";
 
     String rootLink = LinkProvider.getProfileLink(root, LinkProvider.DEFAULT_PORTAL_OWNER);
     String johnLink = LinkProvider.getProfileLink(john, LinkProvider.DEFAULT_PORTAL_OWNER);
+    String maryLink = LinkProvider.getProfileLink(mary, LinkProvider.DEFAULT_PORTAL_OWNER);
+    String demoLink = LinkProvider.getProfileLink(demo, LinkProvider.DEFAULT_PORTAL_OWNER);
 
     activity.setTitle("single @root substitution");
     processor.processActivity(activity);
@@ -79,6 +86,34 @@ public class MentionsProcessorTest extends AbstractCoreTest {
     processor.processActivity(activity);
     assertEquals("Multiple substitution : ",activity.getTitle(), rootLink + " and " + johnLink + " title");
     assertEquals(activity.getBody(), "body with " + rootLink + " and " + johnLink);
+    
+    activity.setTitle("@root. and @john. title");
+    activity.setBody("body with @root. and @john.");
+    processor.processActivity(activity);
+    assertEquals(activity.getTitle(), rootLink + ". and " + johnLink + ". title");
+    assertEquals(activity.getBody(), "body with " + rootLink + ". and " + johnLink + ".");
+    
+    activity.setTitle("@root$#%#^& and @john$#%#^& title");
+    activity.setBody("body with @root$#%#^& and @john$#%#^&");
+    processor.processActivity(activity);
+    assertEquals(activity.getTitle(), rootLink + "$#%#^& and " + johnLink + "$#%#^& title");
+    assertEquals(activity.getBody(), "body with " + rootLink + "$#%#^& and " + johnLink + "$#%#^&");
+    
+    activity.setTitle("@mary.kelly and @demo_gtn title");
+    activity.setBody("body with @mary.kelly. and @demo_gtn.");
+    processor.processActivity(activity);
+    assertEquals(activity.getTitle(), maryLink + " and " + demoLink + " title");
+    assertEquals(activity.getBody(), "body with " + maryLink + ". and " + demoLink + ".");
+    
+    activity.setTitle("@root.1234 and @john.4321 title");
+    activity.setBody("body with @root.1234 and @john.4321");
+    try {
+      processor.processActivity(activity);
+    } catch(Exception e) {
+      assertEquals("Identity must not be null.", e.getMessage());
+      assertEquals(activity.getTitle(), "@root.1234 and @john.4321 title");
+      assertEquals(activity.getBody(), "body with @root.1234 and @john.4321");
+    }
   }
   
   public void testProcessActivityWithTemplateParam() throws Exception {
@@ -102,6 +137,30 @@ public class MentionsProcessorTest extends AbstractCoreTest {
                  templateParams.get("a"));
     assertEquals(LinkProvider.getProfileLink("john", LinkProvider.DEFAULT_PORTAL_OWNER),
                  templateParams.get("b"));    
-    assertEquals("@mary", templateParams.get("d"));  
+    assertEquals("@mary", templateParams.get("d"));
+    
+    // Test process with special character.
+    templateParams = new LinkedHashMap<String, String>();
+    templateParams.put("a", "@mary.kelly. and @demo_gtn");
+    templateParams.put("b", "@mary%$^");
+    templateParams.put("d", "@demo+");
+    templateParams.put(BaseActivityProcessorPlugin.TEMPLATE_PARAM_TO_PROCESS, keysToProcess);
+    activity.setTemplateParams(templateParams);
+    processor.processActivity(activity);
+    
+    templateParams = activity.getTemplateParams();
+    assertEquals(LinkProvider.getProfileLink("mary.kelly", LinkProvider.DEFAULT_PORTAL_OWNER) + ". and " + 
+                 LinkProvider.getProfileLink("demo_gtn", LinkProvider.DEFAULT_PORTAL_OWNER),
+                 templateParams.get("a"));
+    assertEquals(LinkProvider.getProfileLink("mary", LinkProvider.DEFAULT_PORTAL_OWNER) + "%$^",
+                 templateParams.get("b"));    
+    assertEquals("@demo+", templateParams.get("d"));
+  }
+  
+  private Identity createIdentity(String providerId, String remoteId) {
+    Identity identity = new Identity(providerId, remoteId);
+    identityManager.saveIdentity(identity);
+    identity = identityManager.getOrCreateIdentity(providerId, remoteId, true);
+    return identity;
   }
 }


### PR DESCRIPTION
Fix usernames are not processed in ActivityStream if they are preceeded by a dot (.)
