### PR TITLE
SOC-3538: Support shindig configuration externalization

### DIFF
--- a/webapp/opensocial/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/opensocial/src/main/webapp/WEB-INF/web.xml
@@ -29,7 +29,7 @@
   <context-param>
     <param-name>guice-modules</param-name>
     <param-value>
-      org.apache.shindig.common.PropertiesModule:
+      org.exoplatform.portal.gadget.core.ExoPropertiesModule:
       org.exoplatform.social.opensocial.ExoSocialApiGuiceModule:
       org.apache.shindig.gadgets.DefaultGuiceModule:
       org.exoplatform.portal.gadget.core.ExoOAuthModule:


### PR DESCRIPTION
Fix description
    - Use eXo class to read shindig features list
