### PR TITLE
SOC-3556 Show "The target block ID to update is not found : UIComposer" ...

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIComposer.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIComposer.js
@@ -56,7 +56,7 @@
 
       $(document).ready(function() {
         var actionLink = $('#actionLink');
-        if(actionLink.length > 0 && UIComposer.clickOn === null) {
+        if(actionLink.length > 0 && UIComposer.clickOn === null && $(UIComposer.clickOn).hasClass('uidocactivitycomposer') === false) {
           if ($('#InputLink').length == 0) {
             actionLink.trigger('click');
           } else {


### PR DESCRIPTION
...when switch view mode with  User Activity Stream Portlet

Fix description: only add trigger or find element LinkExtensionContainer when UIComposer.clickOn is null and UIComposer.clickOn doesn't have class uidocactivitycomposer.
