### PR TITLE
SOC-3994: [IE] window.location.origin return undefined on IE

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIProfile.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIProfile.js
@@ -28,7 +28,7 @@ var UIProfile = {
     
     // User Profile Popup initialize
 	var portal = eXo.social.portal;
-	var restUrl = window.location.origin + portal.context + '/' + portal.rest + '/social/people' + '/getPeopleInfo/{0}.json';
+	var restUrl = '//' + window.location.host + portal.context + '/' + portal.rest + '/social/people' + '/getPeopleInfo/{0}.json';
     
     var container = $('#' + uicomponentId).closest('.PORTLET-FRAGMENT');
     var userLinks = $(container).find('a:[href*="/profile/"]');


### PR DESCRIPTION
Fix description:
    - Do not use window.location.origin from webkit, use global one instead
