### PR TITLE
SOC-3339 Wrong display profile avatar when trying to comment on activity...

### DIFF
--- a/component/webui/src/main/resources/groovy/social/webui/activity/UIUserProfileActivity.gtmpl
+++ b/component/webui/src/main/resources/groovy/social/webui/activity/UIUserProfileActivity.gtmpl
@@ -363,7 +363,7 @@
 			</div> <!--end commentlist-->
 			<div class="commentList inputContainer" id="InputContainer${activity.id}">
 			<%
-			  def currentCommenterIdentity = Utils.getOwnerIdentity();
+			  def currentCommenterIdentity = Utils.getViewerIdentity();
 			  def currentCommenterUri = LinkProvider.getUserProfileUri(currentCommenterIdentity.getRemoteId());
 			  def currentCommenterAvatar = currentCommenterIdentity.profile.avatarUrl;
 			  def currentCommenterName = currentCommenterIdentity.profile.fullName;


### PR DESCRIPTION
... stream of other people.

Fix description: Get current viewer information, instead of current owner in comment form of user profile activity.
