### PR TITLE
SOC-4162: [My Profile] wrong warning msg when editing Experience

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIExperienceSection.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIExperienceSection.java
@@ -514,7 +514,7 @@ public class UIExperienceSection extends UIProfileSection {
     String endDate = null;
     Boolean isCurrent = null;
     // Check if there is any exception during parsing Date Time field
-    Boolean isDateTimeException = false;
+    boolean isDateTimeException = false;
     Date sDate = null;
     Date eDate = null;
     Date today = new Date();


### PR DESCRIPTION
Problem analysis
    - This problem occurs because of parsing null value

Fix description
    - Verify endate is not null and not empty before parsing
