### PR TITLE
SOC-3505: IE8: Don't show Space Menu portlet after edit layout of page

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
@@ -64,10 +64,11 @@ var UISpaceNavigation = {
       }
     });
 
-
     $('#spaceMenuTab').resize(function(){
-      reset();
-      autoMoveApps();
+      if ($.browser.msie) {
+        reset();
+        autoMoveApps();
+      }
     });    
     
     editedTab.on("dblclick", ".active span", function() {


### PR DESCRIPTION
Problem analysis
    - Resize handler is registered to all elements of DOM in IE. When a component which does not contain Space Menu is triggered, the space menu becomes null
Fix description:
    - In IE, only regiser onresize action on Space Menu's DOM
