### PR TITLE
SOC-4040 Space Activities are visible for everyone

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIUserActivitiesDisplay.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIUserActivitiesDisplay.java
@@ -258,7 +258,8 @@ public class UIUserActivitiesDisplay extends UIContainer {
       activitiesLoader.setActivityListAccess(activitiesListAccess);
       break;
     case POSTER_ACTIVITIES:
-      activitiesListAccess = activityManager.getActivitiesByPoster(ownerIdentity);
+      Identity viewerIdentity = Utils.getViewerIdentity();	
+      activitiesListAccess = activityManager.getActivitiesWithListAccess(ownerIdentity,viewerIdentity);
       activitiesLoader.setActivityListAccess(activitiesListAccess);
       break; 
     default :


### PR DESCRIPTION
Fix description: use method getActivitiesWithListAccess to get the correct view access of current viewer.
