### PR TITLE
SOC-4040 Space Activities are visible for everyone

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIUserActivitiesDisplay.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIUserActivitiesDisplay.java
@@ -89,7 +89,8 @@ public class UIUserActivitiesDisplay extends UIContainer {
     ALL_ACTIVITIES,
     CONNECTIONS,
     MY_SPACE,
-    MY_ACTIVITIES
+    MY_ACTIVITIES,
+    POSTER_ACTIVITIES
   }
 
   private DisplayMode                selectedDisplayMode   = DisplayMode.ALL_ACTIVITIES;


### PR DESCRIPTION
Fix description:
- remove POSTER_ACTIVITIES in display mode list.
- in setOwnerName method, if the viewer is not the owner of activities stream, then the selected display mode is set as owner status.
