### PR TITLE
SOC-4166: Fuzzy syntax misintroduced in search query

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/search/PeopleSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/PeopleSearchConnector.java
@@ -45,6 +45,7 @@ public class PeopleSearchConnector extends AbstractSocialSearchConnector {
 
     List<SearchResult> results = new ArrayList<SearchResult>();
 
+    query = query.substring(0,query.lastIndexOf("~")); //Remove the fuzzy syntax since it's not recognized
     ProfileFilter filter = new ProfileFilter();
     filter.setAll(query);
     filter.setSorting(sorting);

--- a/component/core/src/main/java/org/exoplatform/social/core/search/SpaceSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/SpaceSearchConnector.java
@@ -44,6 +44,7 @@ public class SpaceSearchConnector extends AbstractSocialSearchConnector {
 
     List<SearchResult> results = new ArrayList<SearchResult>();
 
+    query = query.substring(0,query.lastIndexOf("~")); //Remove the fuzzy syntax since it's not recognized
     SpaceFilter filter = new SpaceFilter();
     filter.setSpaceNameSearchCondition(query);
     filter.setSorting(sorting);


### PR DESCRIPTION
Problem analysis:
- By default, fuzzy syntax (i.e: ~0.5) is added to the search query which will be used lately by JCR queries. While, PeopleSearchConnector and SpaceSearchConnector doesn't recognize it and set the query to remove all special characters. So, the query becomes "SEARCH_TEXT+ 0 5" and that's why all profiles/spaces having 0 or 5 in their property values will always appear in search result.
  Fix description:
- Remove the fuzzy syntax since it's not recognized and not used.
