### PR TITLE
SOC-4219: Fuzzy syntax misintroduced in search query

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/search/PeopleSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/PeopleSearchConnector.java
@@ -44,8 +44,9 @@ public class PeopleSearchConnector extends AbstractSocialSearchConnector {
 
     List<SearchResult> results = new ArrayList<SearchResult>();
 
-    if(query.indexOf("~")!=-1)
-      query = query.substring(0,query.lastIndexOf("~")); //Remove the fuzzy syntax since it's not recognized
+    int tildeIdx = query.lastIndexOf("~");
+    if(tildeIdx!=-1)
+      query = query.substring(0,tildeIdx); //Remove the fuzzy syntax since it's not recognized
     ProfileFilter filter = new ProfileFilter();
     filter.setAll(query);
     filter.setSorting(sorting);

--- a/component/core/src/main/java/org/exoplatform/social/core/search/SpaceSearchConnector.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/search/SpaceSearchConnector.java
@@ -43,8 +43,9 @@ public class SpaceSearchConnector extends AbstractSocialSearchConnector {
 
     List<SearchResult> results = new ArrayList<SearchResult>();
 
-    if(query.indexOf("~")!=-1)
-      query = query.substring(0,query.lastIndexOf("~")); //Remove the fuzzy syntax since it's not recognized
+    int tildeIdx = query.lastIndexOf("~");
+    if(tildeIdx!=-1)
+      query = query.substring(0,tildeIdx); //Remove the fuzzy syntax since it's not recognized
     SpaceFilter filter = new SpaceFilter();
     filter.setSpaceNameSearchCondition(query);
     filter.setSorting(sorting);

--- a/component/core/src/test/java/org/exoplatform/social/core/search/PeopleSearchConnectorTestCase.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/search/PeopleSearchConnectorTestCase.java
@@ -131,6 +131,7 @@ public class PeopleSearchConnectorTestCase extends AbstractCoreTest {
     assertEquals(0, peopleSearchConnector.search(null, "non-existent~0.5", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
     assertEquals(1, peopleSearchConnector.search(null, "company0~0.5", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
     assertEquals(0, peopleSearchConnector.search(null, "non-existent", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
+    assertEquals(1, peopleSearchConnector.search(null, "company0", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
   }
 
   public void testData() throws Exception {

--- a/component/core/src/test/java/org/exoplatform/social/core/search/SpaceSearchConnectorTestCase.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/search/SpaceSearchConnectorTestCase.java
@@ -128,7 +128,8 @@ public class SpaceSearchConnectorTestCase extends AbstractCoreTest {
     //Test of a search query containing fuzzy syntax with current offset and limit
     assertEquals(0, spaceSearchConnector.search(context, "non-existent~0.5", Collections.EMPTY_LIST, 0, 5, "relevancy", "ASC").size());
     assertEquals(1, spaceSearchConnector.search(context, "fuzzy~0.5", Collections.EMPTY_LIST, 0, 5, "relevancy", "ASC").size());
-    assertEquals(0, spaceSearchConnector.search(context, "non-existent", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
+    assertEquals(1, spaceSearchConnector.search(context, "non-existent", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
+    assertEquals(1, spaceSearchConnector.search(context, "fuzzy", Collections.EMPTY_LIST, 0, 5, "relevancy", "asc").size());
   }
 
   public void testData() throws Exception {


### PR DESCRIPTION
Problem analysis:
- By default, fuzzy syntax (i.e: ~0.5) is added to the search query which will be used lately by JCR queries. While, PeopleSearchConnector and SpaceSearchConnector doesn't recognize it and set the query to remove all special characters. So, the query becomes "SEARCH_TEXT+ 0 5" and that's why all profiles/spaces having 0 or 5 in their property values will always appear in search result.

Fix description:
- Remove the fuzzy syntax since it's not recognized and not used.
