### PR TITLE
SOC-4337 Unknown error due to missing resource key when edit field "IMs"...

### DIFF
--- a/component/webui/src/main/resources/locale/social/Webui_en.properties
+++ b/component/webui/src/main/resources/locale/social/Webui_en.properties
@@ -280,6 +280,7 @@ UIContactSection.label.gtalk=Gtalk
 UIContactSection.label.msn=Msn
 UIContactSection.label.skype=Skype
 UIContactSection.label.yahoo=Yahoo
+UIContactSection.label.other=Other
 UIContactSection.label.websiteTitle=Website Title
 UIContactSection.label.noGender=Gender Undisclosed
 UIContactSection.label.noUrls=No contact link entered


### PR DESCRIPTION
... in my profile

Fix description: re-add key UIContactSection.label.other for IMs select box.
