### PR TITLE
SOC-4729 Remove unused properties in UISpaceSearch and UIProfileUserSear...

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIProfileUserSearch.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIProfileUserSearch.java
@@ -68,6 +68,16 @@ public class UIProfileUserSearch extends UIForm {
    */
   public static final String REG_FOR_SPLIT = "[^_A-Za-z0-9-.\\s[\\n]]";
 
+  /**
+   * PATTERN FOR CHECK RIGHT INPUT VALUE
+   */
+  static final String RIGHT_INPUT_PATTERN = "^[\\p{L}][\\p{L}._\\- \\d]+$";
+
+  /**
+   * ADD PREFIX TO ENSURE ALWAY RIGHT THE PATTERN FOR CHECKING
+   */
+  static final String PREFIX_ADDED_FOR_CHECK = "PrefixAddedForCheck";
+
   /** Empty character. */
   public static final char EMPTY_CHARACTER = '\u0000';
   

--- a/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIProfileUserSearch.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/profile/UIProfileUserSearch.java
@@ -68,16 +68,6 @@ public class UIProfileUserSearch extends UIForm {
    */
   public static final String REG_FOR_SPLIT = "[^_A-Za-z0-9-.\\s[\\n]]";
 
-  /**
-   * PATTERN FOR CHECK RIGHT INPUT VALUE
-   */
-  static final String RIGHT_INPUT_PATTERN = "^[\\p{L}][\\p{L}._\\- \\d]+$";
-
-  /**
-   * ADD PREFIX TO ENSURE ALWAY RIGHT THE PATTERN FOR CHECKING
-   */
-  static final String PREFIX_ADDED_FOR_CHECK = "PrefixAddedForCheck";
-
   /** Empty character. */
   public static final char EMPTY_CHARACTER = '\u0000';
   

--- a/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSearch.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSearch.java
@@ -62,17 +62,7 @@ public class UISpaceSearch extends UIForm {
   /**
    * DEFAULT SPACE NAME SEARCH.
    */
-  public static final String DEFAULT_SPACE_NAME_SEARCH = "name or description";
-
-  /**
-   * INPUT PATTERN FOR CHECKING.
-   */
-  static final String RIGHT_INPUT_PATTERN = "^[\\p{L}][\\p{L}._\\- \\d]+$";
-  
-  /**
-   * ADD PREFIX TO ENSURE ALWAY RIGHT THE PATTERN FOR CHECKING
-   */
-  static final String PREFIX_ADDED_FOR_CHECK = "PrefixAddedForCheck";
+  public static final String DEFAULT_SPACE_NAME_SEARCH = "name or description";  
   
   private final String POPUP_ADD_SPACE = "UIPopupAddSpace";
 


### PR DESCRIPTION
...ch classes

Fix description: remove properties RIGHT_INPUT_PATTERN and PREFIX_ADDED_FOR_CHECK in UISpaceSearch and UIProfileUserSearch classes.