### PR TITLE
SOC-4767: [Unified Search] All users are displayed in search result for ...

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/SpaceUtils.java
@@ -1555,8 +1555,10 @@ public class SpaceUtils {
    * @return the search condition after process
    */
   public static String processUnifiedSearchCondition(String input) {
-    if (input.isEmpty() || input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
+    if (input.isEmpty()) {
       return input;
+    } else if (input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
+      return input.trim();
     }
     StringBuilder builder = new StringBuilder();
     //The similarity is added for each word in the search condition, ex : space~0.5 test~0.5

--- a/component/core/src/test/java/org/exoplatform/social/core/search/PeopleSearchConnectorTestCase.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/search/PeopleSearchConnectorTestCase.java
@@ -101,6 +101,7 @@ public class PeopleSearchConnectorTestCase extends AbstractCoreTest {
 
   public void testFilter() throws Exception {
     assertEquals(1, peopleSearchConnector.search(null, "foo", Collections.EMPTY_LIST, 0, 10, "relevancy", "asc").size());
+    assertEquals(1, peopleSearchConnector.search(null, " foo", Collections.EMPTY_LIST, 0, 10, "relevancy", "asc").size());
     assertEquals(1, peopleSearchConnector.search(null, "bar", Collections.EMPTY_LIST, 0, 10, "relevancy", "asc").size());
     assertEquals(2, peopleSearchConnector.search(null, "bar position", Collections.EMPTY_LIST, 0, 10, "relevancy", "asc").size());
     assertEquals(2, peopleSearchConnector.search(null, "position", Collections.EMPTY_LIST, 0, 10, "relevancy", "asc").size());


### PR DESCRIPTION
...all search term when fuzzy search is disabled

Problem analysis
- When fuzzy search is disabled, a heading space of search term will not be removed

Fix description
- Remove heading space from search term