### PR TITLE
SOC-4974: [LDAP] NPE in UIBasicProfilePortlet.gtmpl when opening User…

### DIFF
--- a/webapp/portlet/src/main/java/org/exoplatform/social/user/portlet/UserProfileHelper.java
+++ b/webapp/portlet/src/main/java/org/exoplatform/social/user/portlet/UserProfileHelper.java
@@ -94,7 +94,11 @@ public class UserProfileHelper {
    */
   public static Map<String, Object> getDisplayProfileInfo(Profile currentProfile) {
     Map<String, Object> infos = new LinkedHashMap<String, Object>();
-    infos.put(Profile.EMAIL, currentProfile.getEmail());
+    String email = currentProfile.getEmail();
+    // LDAP user might not have email
+    if(!isEmpty(email)) {
+      infos.put(Profile.EMAIL, email);
+    }
     //
     String jobTitle = currentProfile.getPosition();
     if(!isEmpty(jobTitle)) {


### PR DESCRIPTION
… Profile page of a user without email

Fix description:
* Only store user email to profile when it exists.