### PR TITLE
SOC-5147: Deleted users still exist on Connections page

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/listeners/SocialUserEventListenerImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
@@ -140,20 +141,13 @@ public class SocialUserEventListenerImpl extends UserEventListener {
 
   @Override
   public void preDelete(final User user) throws Exception {
-
     RequestLifeCycle.begin(PortalContainer.getInstance());
-    try{
-      ExoContainer container = ExoContainerContext.getCurrentContainer();
-      IdentityManager idm = (IdentityManager) container.getComponentInstanceOfType(IdentityManager.class);
-      Identity identity = idm.getOrCreateIdentity(OrganizationIdentityProvider.NAME, user.getUserName(), true);
-      
-      try {
-        idm.hardDeleteIdentity(identity);
-      } catch (Exception e) {
-        LOG.warn("Problem occurred when deleting user named " + identity.getRemoteId(), e);
-      }
-      
-    }finally{
+    try {
+      Identity identity = CommonsUtils.getService(IdentityStorage.class).findIdentity(OrganizationIdentityProvider.NAME, user.getUserName());
+      CommonsUtils.getService(IdentityManager.class).hardDeleteIdentity(identity);
+    } catch (Exception e) {
+      LOG.warn("Problem occurred when deleting user named " + user.getUserName(), e);
+    } finally{
       RequestLifeCycle.end();
     }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/storage/impl/RelationshipStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/storage/impl/RelationshipStorageImpl.java
@@ -256,11 +256,12 @@ public class RelationshipStorageImpl extends AbstractStorage implements Relation
       }
       
       identity = createIdentityFromEntity(entity);
-      identities.add(identity);
-
-      if (limit != -1 && limit > 0 && ++i >= limit) {
-        break;
-     }
+      if (!identity.isDeleted()) {
+        identities.add(identity);
+        if (limit != -1 && limit > 0 && ++i >= limit) {
+          break;
+        }
+      }
     }
 
     return new ArrayList<Identity>(identities);


### PR DESCRIPTION
Fix description:
- SocialUserEventListenerImpl.preDelete: check the existence of user identity in social workspace, skip the verification in OrganizationService.
- Improve IdentityStorageImpl._hardDeleteIdentity
