### PR TITLE
SOC-5289: Accessing a page having space name display it in space navigations

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/Utils.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/Utils.java
@@ -813,6 +813,11 @@ public class Utils {
       String groupId = String.format("%s/%s", SpaceUtils.SPACE_GROUP, spacePrettyName);
       space = spaceService.getSpaceByGroupId(groupId); 
     }
+
+    if(!pcontext.getControllerContext().getParameter(RequestNavigationData.REQUEST_SITE_TYPE).equals("group")) {
+      //If the URL is not from Group Site like /portal/intranet/{SpaceName}
+      return null;
+    }
      
     
     return space;


### PR DESCRIPTION
Ensure that the URL is from group site otherwise, it will return NULL space.
