### PR TITLE
[SOC-5750] Exceptions raised during activities migrations

### DIFF
--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
@@ -284,6 +284,10 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     }
 
     Identity jpaIdentity = identityJPAStorage.findIdentity(identityEntity.getProviderId(), identityEntity.getRemoteId());
+    if(jpaIdentity == null) {
+      LOG.warn("The identity of the user " + identityEntity.getRemoteId() + " was not found in migrated identities. Do not migrate activities for this user.");
+      return;
+    }
 
     String type = (OrganizationIdentityProvider.NAME.equals(providerId)) ? "user" : "space";
     LOG.info(String.format("    Migration activities for %s: %s", type, identityEntity.getRemoteId()));
@@ -306,6 +310,10 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         }
 
         ExoSocialActivity activity = activityJCRStorage.getActivity(activityId);
+        if(activity == null) {
+          LOG.info("Activity with ID=" + activityId + " could not be found, ignoring it!");
+          continue;
+        }
         Map<String, String> params = activity.getTemplateParams();
 
         if (params != null && !params.isEmpty()) {


### PR DESCRIPTION
These exceptions are raised when the activity is null or the identitity is null. The purpose of this PR is to handle the nullity of activity and identity by logging a significant log message.