### PR TITLE
FIX SOC-6206: Cancel button does not work properly

### DIFF
--- a/webapp/vue-portlet/src/main/webapp/spaces-administration-app/components/ExoSpacesAdministrationSpacesPermissions.vue
+++ b/webapp/vue-portlet/src/main/webapp/spaces-administration-app/components/ExoSpacesAdministrationSpacesPermissions.vue
@@ -300,9 +300,9 @@ export default {
       if(this.spacesCreatorsEditMode) {
         this.spacesCreatorsEditMode = false;
       } else {
-        this.getSettingValueCreateSpace();
         this.spacesCreatorsEditMode = true;
       }
+      this.getSettingValueCreateSpace();
     },
     editManageSpace(){
       $('.tooltip.fade.bottom.in').remove();


### PR DESCRIPTION
After clicking on cancel button, the added spaces will still be appeared in the main table. To avoid that, the method getSettingValueCreateSpace() must be called after the cancel event also.