### PR TITLE
SOC-6236 : add a property to allow to disable link preview in activities

### DIFF
--- a/component/service/src/test/java/org/exoplatform/social/service/rest/LinkShareTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/service/rest/LinkShareTest.java
@@ -1,0 +1,31 @@
+package org.exoplatform.social.service.rest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LinkShareTest {
+  @Test
+  public void shouldNotFetchLinkPreviewWhenPreviewIsDisabled() throws Exception {
+    // Given
+    String previousPropertyValue = System.getProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY);
+    System.setProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY, "false");
+
+    try {
+      // When
+      LinkShare linkShare = LinkShare.getInstance("http://dummy.url.com");
+
+      // Then
+      assertNotNull(linkShare);
+      assertEquals("http://dummy.url.com", linkShare.getLink());
+      assertEquals("", linkShare.getDescription());
+      assertNull(linkShare.getMediaObject());
+    } finally {
+      if (previousPropertyValue == null) {
+        System.clearProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY);
+      } else {
+        System.setProperty(LinkShare.ACTIVITY_LINK_PREVIEW_ENABLED_PROPERTY, previousPropertyValue);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Thanks to link preview in activities, it is possible to exploit SSRF vulnerabilities.

In order to prevent that, this fix allows to disable the link preview in activities with a new property called exo.activity.link.preview.enabled (defaults to true).