### PR TITLE
Fix application of sort field parameter in identities

### DIFF
--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/search/ExtendProfileFilter.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/search/ExtendProfileFilter.java
@@ -189,6 +189,16 @@ public class ExtendProfileFilter extends ProfileFilter {
   }
 
   @Override
+  public String getFirstCharFieldName() {
+    return delegate.getFirstCharFieldName();
+  }
+
+  @Override
+  public void setFirstCharFieldName(String firstCharField) {
+    delegate.setFirstCharFieldName(firstCharField);
+  }
+
+  @Override
   public String getAll() {
     return delegate.getAll();
   }

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAOTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/dao/IdentityDAOTest.java
@@ -29,12 +29,10 @@ import org.exoplatform.social.core.jpa.test.BaseCoreTest;
 import org.exoplatform.social.core.relationship.model.Relationship.Type;
 
 import javax.persistence.EntityExistsException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
+
+import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
@@ -182,7 +180,41 @@ public class IdentityDAOTest extends BaseCoreTest {
     assertTrue(identitiesList.size() >= 20);
     Iterator<String> iterator = identitiesList.iterator();
     while (iterator.hasNext()) {
-      String username = (String) iterator.next();
+      String username = iterator.next();
+      if (!username.startsWith(userPrefix)) {
+        iterator.remove();
+      }
+    }
+    List<String> identitiesListBackup = new ArrayList<>(identitiesList);
+    Collections.sort(identitiesList);
+    assertEquals("List '" + identitiesList + "' is not sorted", identitiesList, identitiesListBackup);
+  }
+
+  public void testFindAllIdentitiesWithConnectionsSorted() throws Exception {
+    String userPrefix = "userSorted";
+    for (int i = 20; i > 0; i--) {
+      String remoteId = userPrefix + i;
+      IdentityEntity identityUser = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, remoteId));
+      deleteIdentities.add(identityUser);
+      identityUser.getProperties().put(Profile.FULL_NAME, remoteId);
+      identityDAO.update(identityUser);
+    }
+
+    IdentityEntity identityUser0 = identityDAO.create(createIdentity(OrganizationIdentityProvider.NAME, "userWithConn0"));
+    deleteIdentities.add(identityUser0);
+
+    ListAccess<Entry<IdentityEntity, ConnectionEntity>> identitiesListAccess =
+                                                                             identityDAO.findAllIdentitiesWithConnections(identityUser0.getId(),
+                                                                                                                          null,
+                                                                                                                          '\u0000',
+                                                                                                                          null,
+                                                                                                                          null);
+    Entry<IdentityEntity, ConnectionEntity>[] identitiesEntries = identitiesListAccess.load(0, Integer.MAX_VALUE);
+    List<String> identitiesList = Arrays.stream(identitiesEntries).map(entry -> entry.getKey().getRemoteId()).collect(Collectors.toList());
+    assertTrue(identitiesList.size() >= 20);
+    Iterator<String> iterator = identitiesList.iterator();
+    while (iterator.hasNext()) {
+      String username = iterator.next();
       if (!username.startsWith(userPrefix)) {
         iterator.remove();
       }

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/IdentityManagerImpl.java
@@ -112,7 +112,7 @@ public class IdentityManagerImpl implements IdentityManager {
         this.defaultSorting = configuredSorting;
       }
 
-      String firstCharacterFilteringField = this.firstCharacterFiltering;
+      String firstCharacterFilteringField = DEFAULT_FIRST_CHAR_FILTERING;
       if (initParams.containsKey("firstChar.field.name")) {
         firstCharacterFilteringField = initParams.getValueParam("firstChar.field.name").getValue();
       }

--- a/component/core/src/main/java/org/exoplatform/social/core/profile/ProfileFilter.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/profile/ProfileFilter.java
@@ -67,7 +67,7 @@ public class ProfileFilter implements Cloneable {
 
   private Sorting sorting;
 
-  private String firstCharFieldName = SortBy.LASTNAME.getFieldName();
+  private String firstCharFieldName = null;
 
   public ProfileFilter() {
     this.name = "";

--- a/component/webui/src/main/java/org/exoplatform/social/webui/connections/UIAllPeople.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/connections/UIAllPeople.java
@@ -425,13 +425,12 @@ public class UIAllPeople extends UIContainer {
       try {
         uiAllPeople.setSelectedChar(charSearch);
         if (charSearch != null) { // search by alphabet
-          filter.setName(charSearch);
+          filter.setName("");
           filter.setPosition("");
           filter.setSkills("");
           filter.setFirstCharacterOfName(charSearch.toCharArray()[0]);
           if (ALL_FILTER.equals(charSearch)) {
             filter.setFirstCharacterOfName(EMPTY_CHARACTER);
-            filter.setName("");
           }
           uiSearch.setRawSearchConditional("");
         } else if (ALL_FILTER.equals(uiSearch.getRawSearchConditional())) {

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -257,21 +257,6 @@
         <set-method>registerIdentityProviders</set-method>
         <type>org.exoplatform.social.core.identity.IdentityProviderPlugin</type>
         <init-params>
-          <value-param>
-            <name>sort.field.name</name>
-            <description>Identities sort field name</description>
-            <value>${exo.social.identity.sort.field:fullname}</value>
-          </value-param>
-          <value-param>
-            <name>sort.order.direction</name>
-            <description>Identities sort field name</description>
-            <value>${exo.social.identity.sort.direction:asc}</value>
-          </value-param>
-          <value-param>
-            <name>firstChar.field.name</name>
-            <description>Identities sort field name</description>
-            <value>${exo.social.identity.firstChar.field:lastname}</value>
-          </value-param>
           <values-param>
             <name>providers</name>
             <description>Identity Providers</description>
@@ -280,6 +265,23 @@
         </init-params>
       </component-plugin>
     </component-plugins>
+    <init-params>
+      <value-param>
+        <name>sort.field.name</name>
+        <description>Identities sort field name</description>
+        <value>${exo.social.identity.sort.field:fullname}</value>
+      </value-param>
+      <value-param>
+        <name>sort.order.direction</name>
+        <description>Identities sort direction</description>
+        <value>${exo.social.identity.sort.direction:asc}</value>
+      </value-param>
+      <value-param>
+        <name>firstChar.field.name</name>
+        <description>Identities first char filtering field name</description>
+        <value>${exo.social.identity.firstChar.field:lastname}</value>
+      </value-param>
+    </init-params>
   </component>
 
   <component>

--- a/webapp/portlet/src/main/java/org/exoplatform/social/portlet/UIMembersPortlet.java
+++ b/webapp/portlet/src/main/java/org/exoplatform/social/portlet/UIMembersPortlet.java
@@ -440,13 +440,12 @@ public class UIMembersPortlet extends UIPortletApplication {
       try {
         uiMembersPortlet.setSelectedChar(charSearch);
         if (charSearch != null) { // search by alphabet
-          filter.setName(charSearch);
+          filter.setName("");
           filter.setPosition("");
           filter.setSkills("");
           filter.setFirstCharacterOfName(charSearch.toCharArray()[0]);
           if (ALL_FILTER.equals(charSearch)) {
             filter.setFirstCharacterOfName(EMPTY_CHARACTER);
-            filter.setName("");
           }
           uiSearch.setRawSearchConditional("");
         } 


### PR DESCRIPTION
This PR:
* applies the init params of sorting parameters on component instead of component plugin
* Fix call of IdentityManager on service layer from WebUI component, so that the filter is considered empty even when a "first character" filter is applied.
* Apply an additional sort of returned set of entries coming from Map switch the sort applied using RDBMS query