### PR TITLE
PLF-6637 : display only allowed groups for user (#500)

### DIFF
--- a/component/webui/pom.xml
+++ b/component/webui/pom.xml
@@ -29,6 +29,9 @@
   <packaging>jar</packaging>
   <name>eXo PLF:: Social Web UI Component</name>
   <description>eXo Social Web UI Component</description>
+  <properties>
+    <exo.test.coverage.ratio>0.004</exo.test.coverage.ratio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -257,6 +260,12 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/component/webui/src/main/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPlugin.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPlugin.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2019 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.exoplatform.social.webui;
+
+import org.exoplatform.portal.config.GroupVisibilityPlugin;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.space.SpacesAdministrationService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of GroupVisibilityPlugin for space creation which allows to
+ * see a group if any of these conditions is fulfilled:
+ * * the given user is the super user
+ * * the given user is a platform administrator
+ * * the given user is a manager of the group
+ * * the group is a space group and the given user is a spaces administrator
+ */
+public class SpaceCreationInvitationGroupVisibilityPlugin extends GroupVisibilityPlugin {
+
+  public static final String          MANAGER = "manager";
+
+  public static final String          ANY     = "*";
+
+  private UserACL                     userACL;
+
+  private SpacesAdministrationService spacesAdministrationService;
+
+  private List<String>                spacesAdministratorsGroups;
+
+  public SpaceCreationInvitationGroupVisibilityPlugin(UserACL userACL, SpacesAdministrationService spacesAdministrationService) {
+    this.userACL = userACL;
+    this.spacesAdministrationService = spacesAdministrationService;
+  }
+
+  @Override
+  public boolean hasPermission(Identity userIdentity, Group group) {
+    if (userACL.getSuperUser().equals(userIdentity.getUserId())
+        || userIdentity.getMemberships()
+                       .stream()
+                       .anyMatch(userMembership -> userMembership.getGroup().equals(userACL.getAdminGroups()))) {
+      return true;
+    }
+
+    Collection<MembershipEntry> userMemberships = userIdentity.getMemberships();
+    if (spacesAdministratorsGroups == null) {
+      spacesAdministratorsGroups = spacesAdministrationService.getSpacesAdministratorsMemberships()
+                                                              .stream()
+                                                              .map(membershipEntry -> membershipEntry.getGroup())
+                                                              .collect(Collectors.toList());
+    }
+    return userMemberships.stream()
+                          .anyMatch(userMembership -> ((group.getId().startsWith("/spaces/")
+                              || group.getId().equals("/spaces"))
+                              && (spacesAdministratorsGroups.contains(userMembership.getGroup())
+                                  || userMembership.getGroup().equals(group.getId())
+                                  || userMembership.getGroup().startsWith(group.getId() + "/")))
+                              || ((userMembership.getGroup().equals(group.getId())
+                                  || userMembership.getGroup().startsWith(group.getId() + "/"))
+                                  && (userMembership.getMembershipType().equals(ANY)
+                                      || userMembership.getMembershipType().equals(MANAGER))));
+  }
+}

--- a/component/webui/src/main/java/org/exoplatform/social/webui/UISocialGroupSelector.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/UISocialGroupSelector.java
@@ -17,342 +17,48 @@
 
 package org.exoplatform.social.webui;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.web.application.ApplicationMessage;
-import org.exoplatform.web.application.RequestContext;
-import org.exoplatform.webui.application.WebuiRequestContext;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.config.annotation.ComponentConfigs;
 import org.exoplatform.webui.config.annotation.EventConfig;
-import org.exoplatform.webui.core.UIApplication;
 import org.exoplatform.webui.core.UIBreadcumbs;
-import org.exoplatform.webui.core.UIComponent;
-import org.exoplatform.webui.core.UIContainer;
-import org.exoplatform.webui.core.UIPopupWindow;
 import org.exoplatform.webui.core.UITree;
-import org.exoplatform.webui.core.UIBreadcumbs.LocalPath;
-import org.exoplatform.webui.event.Event;
-import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.event.Event.Phase;
-import org.exoplatform.webui.form.UIForm;
+import org.exoplatform.webui.organization.account.UIGroupSelector;
 
 @ComponentConfigs({
-  @ComponentConfig(
-    template = "war:/groovy/social/webui/space/UISocialGroupSelector.gtmpl",
-    events = {
-      @EventConfig(phase = Phase.DECODE, listeners = UISocialGroupSelector.ChangeNodeActionListener.class),
-      @EventConfig(phase = Phase.DECODE, listeners = UISocialGroupSelector.SelectGroupActionListener.class),
-      @EventConfig(phase = Phase.DECODE, listeners = UISocialGroupSelector.SelectPathActionListener.class)
-    }
-   ),
-   @ComponentConfig(
-     type = UIFilterableTree.class,
-     id = "UITreeGroupSelector",
-     template = "war:/groovy/social/webui/UIFilterableTree.gtmpl",
-     events = @EventConfig(listeners = UIFilterableTree.ChangeNodeActionListener.class, phase = Phase.DECODE)
-   ),
-   @ComponentConfig(
-     type = UIBreadcumbs.class,
-     id = "BreadcumbGroupSelector",
-     template = "system:/groovy/webui/core/UIBreadcumbs.gtmpl",
-     events = @EventConfig(phase = Phase.DECODE, listeners = UIBreadcumbs.SelectPathActionListener.class))
-})
-public class UISocialGroupSelector extends UIContainer {
-  final static public String MANAGER = "manager";
-  final static public String ANY = "*";
-  
-  private static Log LOG = ExoLogger.getLogger(UISocialGroupSelector.class);
-  private Group selectGroup_;
+    @ComponentConfig(template = "war:/groovy/social/webui/space/UISocialGroupSelector.gtmpl", events = {
+        @EventConfig(phase = Phase.DECODE, listeners = UIGroupSelector.ChangeNodeActionListener.class),
+        @EventConfig(phase = Phase.DECODE, listeners = UIGroupSelector.SelectGroupActionListener.class),
+        @EventConfig(phase = Phase.DECODE, listeners = UIGroupSelector.SelectPathActionListener.class) }),
+    @ComponentConfig(type = UITree.class, id = "UITreeGroupSelector", template = "system:/groovy/webui/core/UITree.gtmpl", events = @EventConfig(phase = Phase.DECODE, listeners = UITree.ChangeNodeActionListener.class)),
+    @ComponentConfig(type = UIBreadcumbs.class, id = "BreadcumbGroupSelector", template = "system:/groovy/webui/core/UIBreadcumbs.gtmpl", events = @EventConfig(phase = Phase.DECODE, listeners = UIBreadcumbs.SelectPathActionListener.class)) })
+public class UISocialGroupSelector extends UIGroupSelector {
 
-  @SuppressWarnings("unchecked")
   public UISocialGroupSelector() throws Exception {
-    UIBreadcumbs uiBreadcumbs = addChild(UIBreadcumbs.class,
-        "BreadcumbGroupSelector", "BreadcumbGroupSelector");
-    UITree tree = addChild(UIFilterableTree.class, "UITreeGroupSelector",
-        "TreeGroupSelector");
-    OrganizationService service = getApplicationComponent(OrganizationService.class);
-    Collection<?> sibblingsGroup = service.getGroupHandler().findGroups(
-        null);
-
-    tree.setSibbling((List) sibblingsGroup);
-    tree.setIcon("GroupAdminIcon");
-    tree.setSelectedIcon("PortalIcon");
-    tree.setBeanIdField("id");
-    tree.setBeanLabelField("label");
-    uiBreadcumbs.setBreadcumbsStyle("UIExplorerHistoryPath");
-    setupFilterableTree();
+    super();
   }
 
-  public Group getCurrentGroup() {
-    return selectGroup_;
-  }
+  @Override
+  protected List<Group> getGroups(Group parentGroup) throws Exception {
+    OrganizationService organizationService = getApplicationComponent(OrganizationService.class);
+    UserACL userACL = getApplicationComponent(UserACL.class);
 
-  public List<String> getListGroup() throws Exception {
-    OrganizationService service = getApplicationComponent(OrganizationService.class);
-    List<String> listGroup = new ArrayList<String>();
-    RequestContext reqCtx = RequestContext.getCurrentInstance();
-    String remoteUser = reqCtx.getRemoteUser();
-    if (getCurrentGroup() == null)
-      return null;
-    Collection<Group> groups = service.getGroupHandler().findGroups(getCurrentGroup());
-    if (groups.size() > 0) {
-      for (Object child : groups) {
-        Group childGroup = (Group) child;
-        Membership membership = getMemberShip(remoteUser, childGroup.getId());
-            
-        if (membership != null) {
-          listGroup.add(childGroup.getId());
-        }
-      }
+    ConversationState conversationState = ConversationState.getCurrent();
+    if(conversationState != null && conversationState.getIdentity() != null) {
+      return organizationService.getGroupHandler().findGroups(parentGroup)
+              .stream()
+              .filter(group -> userACL.hasPermission(conversationState.getIdentity(), group, "space_creation_invitation"))
+              .collect(Collectors.toList());
+    } else {
+      return Collections.EMPTY_LIST;
     }
-    return listGroup;
-  }
-
-  public String event(String name, String beanId) throws Exception {
-    UIForm uiForm = getAncestorOfType(UIForm.class);
-    if (uiForm != null)
-      return uiForm.event(name, getId(), beanId);
-    return super.event(name, beanId);
-  }
-
-  /**
-   * Reset tree into the current selected group.
-   *
-   * @param groupId
-   * @throws Exception
-   */
-  @SuppressWarnings("unchecked")
-  private void changeGroup(String groupId) throws Exception {
-    OrganizationService service = getApplicationComponent(OrganizationService.class);
-    UIBreadcumbs uiBreadcumb = getChild(UIBreadcumbs.class);
-    uiBreadcumb.setPath(getPath(null, groupId));
-
-    UITree tree = getChild(UIFilterableTree.class);
-    Collection<?> sibblingGroup;
-
-    if (groupId == null) {
-      sibblingGroup = service.getGroupHandler().findGroups(null);
-      tree.setSibbling((List) sibblingGroup);
-      tree.setChildren(null);
-      tree.setSelected(null);
-      selectGroup_ = null;
-      return;
-    }
-
-    selectGroup_ = service.getGroupHandler().findGroupById(groupId);
-    String parentGroupId = null;
-    if (selectGroup_ != null)
-      parentGroupId = selectGroup_.getParentId();
-    Group parentGroup = null;
-    if (parentGroupId != null)
-      parentGroup = service.getGroupHandler()
-          .findGroupById(parentGroupId);
-
-    Collection childrenGroup = service.getGroupHandler().findGroups(
-        selectGroup_);
-    sibblingGroup = service.getGroupHandler().findGroups(parentGroup);
-
-    tree.setSibbling((List) sibblingGroup);
-    tree.setChildren((List) childrenGroup);
-    tree.setSelected(selectGroup_);
-    tree.setParentSelected(parentGroup);
-  }
-
-  /**
-   * Get path of the group in tree.
-   *
-   * @param list
-   * @param id
-   * @return
-   * @throws Exception
-   */
-  private List<LocalPath> getPath(List<LocalPath> list, String id)
-      throws Exception {
-    if (list == null)
-      list = new ArrayList<LocalPath>(5);
-    if (id == null)
-      return list;
-    OrganizationService service = getApplicationComponent(OrganizationService.class);
-    Group group = service.getGroupHandler().findGroupById(id);
-    if (group == null)
-      return list;
-    list.add(0, new LocalPath(group.getId(), group.getGroupName()));
-    getPath(list, group.getParentId());
-    return list;
-  }
-
-  /**
-   * Set up tree at start up.
-   *
-   */
-  private void setupFilterableTree() {
-    UIFilterableTree.TreeNodeFilter nodeFilter = new UIFilterableTree.TreeNodeFilter() {
-
-      public boolean filterThisNode(Object nodeObject,
-          WebuiRequestContext context) {
-        String remoteUser = context.getRemoteUser();
-        OrganizationService service = getApplicationComponent(OrganizationService.class);
-
-        if (remoteUser == null) {
-          return true;
-        }
-
-        if (!(nodeObject instanceof Group)) {
-          return true;
-        }
-
-        Group group = (Group) nodeObject;
-
-        OrganizationService orgService = getApplicationComponent(OrganizationService.class);
-        ;
-        Membership membership = null;
-        try {
-          membership = getMemberShip(remoteUser, group.getId());
-        } catch (Exception e) {
-          LOG.warn("Error when finding membership for filtering tree node", e);
-        }
-
-        if (membership != null) {
-          return false;
-        }
-
-        List<Group> groups = null;
-        try {
-          groups = (List) service.getGroupHandler().findGroups(group);
-          boolean existMembership = checkMembershipOfChildren(groups,
-              orgService, remoteUser);
-          
-          for (Group childGroup : groups) {
-            if (!existMembership) {
-              List<Group> childGroups = null;
-              childGroups = (List) service.getGroupHandler().findGroups(childGroup);
-              boolean hasMembership = checkMembershipOfChildren(childGroups, orgService, remoteUser);
-              if (hasMembership) {
-                return (!hasMembership);
-              }
-            }
-          }
-          
-          return (!existMembership);
-        } catch (Exception e) {
-          LOG.warn("Error when filtering tree node", e);
-        }
-
-        return true;
-      }
-
-      private boolean checkMembershipOfChildren(List<Group> groups,
-          OrganizationService orgService, String remoteUser) {
-        Membership membership = null;
-        for (Group group : groups) {
-          try {
-            membership = getMemberShip(remoteUser, group.getId());
-          } catch (Exception e) {
-            LOG.warn("Error when filtering tree node", e);
-          }
-
-          if (membership != null) {
-            return true;
-          }
-        }
-
-        return false;
-      }
-
-    };
-
-    this.getChild(UIFilterableTree.class).setTreeNodeFilter(nodeFilter);
-  }
-
-  static public class ChangeNodeActionListener extends
-      EventListener<UIFilterableTree> {
-    public void execute(Event<UIFilterableTree> event) throws Exception {
-      UISocialGroupSelector uiGroupSelector = event.getSource()
-          .getAncestorOfType(UISocialGroupSelector.class);
-      String groupId = event.getRequestContext().getRequestParameter(
-          OBJECTID);
-      uiGroupSelector.changeGroup(groupId);
-      event.getRequestContext().addUIComponentToUpdateByAjax(
-          uiGroupSelector);
-    }
-  }
-
-  static public class SelectGroupActionListener extends
-      EventListener<UISocialGroupSelector> {
-    public void execute(Event<UISocialGroupSelector> event)
-        throws Exception {
-      UISocialGroupSelector uiSelector = event.getSource();
-      UIComponent uiPermission = uiSelector.<UIComponent> getParent()
-          .getParent();
-      WebuiRequestContext pcontext = event.getRequestContext();
-
-      UIPopupWindow uiPopup = uiSelector.getParent();
-      UIForm uiForm = event.getSource().getAncestorOfType(UIForm.class);
-      if (uiForm != null) {
-        event.getRequestContext().addUIComponentToUpdateByAjax(
-            uiForm.getParent());
-      } else {
-        event.getRequestContext().addUIComponentToUpdateByAjax(uiPopup);
-      }
-      if (uiSelector.getCurrentGroup() == null) {
-        UIApplication uiApp = pcontext.getUIApplication();
-        uiApp.addMessage(new ApplicationMessage(
-            "UIGroupSelector.msg.selectGroup", null));
-        //pcontext.addUIComponentToUpdateByAjax(uiApp.getUIPopupMessages());
-        uiPopup.setShow(true);
-        return;
-      }
-
-      uiPermission.broadcast(event, event.getExecutionPhase());
-      uiPopup.setShow(false);
-
-    }
-  }
-
-  static public class SelectPathActionListener extends
-      EventListener<UIBreadcumbs> {
-    public void execute(Event<UIBreadcumbs> event) throws Exception {
-      UIBreadcumbs uiBreadcumbs = event.getSource();
-      UISocialGroupSelector uiSelector = uiBreadcumbs.getParent();
-      String objectId = event.getRequestContext().getRequestParameter(
-          OBJECTID);
-      uiBreadcumbs.setSelectPath(objectId);
-      String selectGroupId = uiBreadcumbs.getSelectLocalPath().getId();
-      uiSelector.changeGroup(selectGroupId);
-
-      UIPopupWindow uiPopup = uiSelector.getParent();
-      uiPopup.setShow(true);
-
-      UIForm uiForm = event.getSource().getAncestorOfType(UIForm.class);
-      if (uiForm != null) {
-        event.getRequestContext().addUIComponentToUpdateByAjax(
-            uiForm.getParent());
-      } else {
-        event.getRequestContext().addUIComponentToUpdateByAjax(uiPopup);
-      }
-    }
-  }
-  
-  private Membership getMemberShip(String remoteUser, String id) throws Exception {
-    OrganizationService service = getApplicationComponent(OrganizationService.class);
-    Membership membership = service.getMembershipHandler()
-    .findMembershipByUserGroupAndType(remoteUser,
-        id, MANAGER);
-    
-    if (membership == null) {
-      membership = service.getMembershipHandler()
-          .findMembershipByUserGroupAndType(remoteUser,
-              id, ANY);
-    }
-    
-    return membership;
   }
 }

--- a/component/webui/src/test/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPluginTest.java
+++ b/component/webui/src/test/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPluginTest.java
@@ -1,0 +1,135 @@
+package org.exoplatform.social.webui;
+
+import org.exoplatform.portal.config.GroupVisibilityPlugin;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.impl.GroupImpl;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.space.SpacesAdministrationService;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SpaceCreationInvitationGroupVisibilityPluginTest {
+  @Test
+  public void shouldHasPermissionWhenUserIsSuperUser() {
+    // Given
+    UserACL userACL = mock(UserACL.class);
+    when(userACL.getSuperUser()).thenReturn("john");
+    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
+    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
+                                                                                                                        "*")));
+    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
+
+    Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/users", "manager")));
+    Group groupPlatform = new GroupImpl();
+    groupPlatform.setId("/platform");
+    Group groupPlatformUsers = new GroupImpl();
+    groupPlatformUsers.setId("/platform/users");
+
+    // When
+    boolean hasPermissionOnPlatform = plugin.hasPermission(userIdentity, groupPlatform);
+    boolean hasPermissionOnPlatformUsers = plugin.hasPermission(userIdentity, groupPlatformUsers);
+
+    // Then
+    assertTrue(hasPermissionOnPlatform);
+    assertTrue(hasPermissionOnPlatformUsers);
+  }
+
+  @Test
+  public void shouldHasPermissionOnSpacesGroupsWhenUserIsSpaceAdministrator() {
+    // Given
+    UserACL userACL = mock(UserACL.class);
+    when(userACL.getSuperUser()).thenReturn("root");
+    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
+    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
+                                                                                                                        "*")));
+    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
+
+    Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/spacesadmins", "manager")));
+    Group groupSpaces = new GroupImpl();
+    groupSpaces.setId("/spaces");
+    Group groupSpacesMarketing = new GroupImpl();
+    groupSpacesMarketing.setId("/spaces/marketing");
+    Group groupSpacesSales = new GroupImpl();
+    groupSpacesSales.setId("/spaces/sales");
+    Group groupSpacesEngineering = new GroupImpl();
+    groupSpacesEngineering.setId("/spaces/engineering");
+
+    // When
+    boolean hasPermissionOnSpaces = plugin.hasPermission(userIdentity, groupSpaces);
+    boolean hasPermissionOnSpacesMarketing = plugin.hasPermission(userIdentity, groupSpacesMarketing);
+    boolean hasPermissionOnSpacesSales = plugin.hasPermission(userIdentity, groupSpacesSales);
+    boolean hasPermissionOnSpacesEngineering = plugin.hasPermission(userIdentity, groupSpacesEngineering);
+
+    // Then
+    assertTrue(hasPermissionOnSpaces);
+    assertTrue(hasPermissionOnSpacesMarketing);
+    assertTrue(hasPermissionOnSpacesSales);
+    assertTrue(hasPermissionOnSpacesEngineering);
+  }
+
+  @Test
+  public void shouldHasPermissionWhenUserIsInGivenGroup() {
+    // Given
+    UserACL userACL = mock(UserACL.class);
+    when(userACL.getSuperUser()).thenReturn("root");
+    when(userACL.getAdminGroups()).thenReturn("/platform/administrators");
+    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
+    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
+                                                                                                                        "*")));
+    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
+
+    Identity userIdentity = new Identity("john",
+                                         Arrays.asList(new MembershipEntry("/platform/developers", "manager"),
+                                                       new MembershipEntry("/platform/testers", "member"),
+                                                       new MembershipEntry("/spaces/marketing", "member"),
+                                                       new MembershipEntry("/spaces/sales", "manager"),
+                                                       new MembershipEntry("/organization/rh", "*")));
+    Group groupPlatform = new GroupImpl();
+    groupPlatform.setId("/platform");
+    Group groupPlatformDevelopers = new GroupImpl();
+    groupPlatformDevelopers.setId("/platform/developers");
+    Group groupPlatformTesters = new GroupImpl();
+    groupPlatformTesters.setId("/platform/testers");
+    Group groupSpaces = new GroupImpl();
+    groupSpaces.setId("/spaces");
+    Group groupSpacesMarketing = new GroupImpl();
+    groupSpacesMarketing.setId("/spaces/marketing");
+    Group groupSpacesSales = new GroupImpl();
+    groupSpacesSales.setId("/spaces/sales");
+    Group groupSpacesEngineering = new GroupImpl();
+    groupSpacesEngineering.setId("/spaces/engineering");
+    Group groupOrganization = new GroupImpl();
+    groupOrganization.setId("/organization");
+    Group groupOrganizationRh = new GroupImpl();
+    groupOrganizationRh.setId("/organization/rh");
+
+    // When
+    boolean hasPermissionOnPlatform = plugin.hasPermission(userIdentity, groupPlatform);
+    boolean hasPermissionOnPlatformDevelopers = plugin.hasPermission(userIdentity, groupPlatformDevelopers);
+    boolean hasPermissionOnPlatformTesters = plugin.hasPermission(userIdentity, groupPlatformTesters);
+    boolean hasPermissionOnSpaces = plugin.hasPermission(userIdentity, groupSpaces);
+    boolean hasPermissionOnSpacesMarketing = plugin.hasPermission(userIdentity, groupSpacesMarketing);
+    boolean hasPermissionOnSpacesSales = plugin.hasPermission(userIdentity, groupSpacesSales);
+    boolean hasPermissionOnSpacesEngineering = plugin.hasPermission(userIdentity, groupSpacesEngineering);
+    boolean hasPermissionOnOrganization = plugin.hasPermission(userIdentity, groupOrganization);
+    boolean hasPermissionOnOrganizationRh = plugin.hasPermission(userIdentity, groupOrganizationRh);
+
+    // Then
+    assertTrue(hasPermissionOnPlatform);
+    assertTrue(hasPermissionOnPlatformDevelopers);
+    assertFalse(hasPermissionOnPlatformTesters);
+    assertTrue(hasPermissionOnSpaces);
+    assertTrue(hasPermissionOnSpacesMarketing);
+    assertTrue(hasPermissionOnSpacesSales);
+    assertFalse(hasPermissionOnSpacesEngineering);
+    assertTrue(hasPermissionOnOrganization);
+    assertTrue(hasPermissionOnOrganizationRh);
+  }
+}

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/core-configuration.xml
@@ -899,4 +899,13 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.portal.config.UserACL</target-component>
+    <component-plugin>
+      <name>space_creation_invitation</name>
+      <set-method>addGroupVisibilityPlugin</set-method>
+      <type>org.exoplatform.social.webui.SpaceCreationInvitationGroupVisibilityPlugin</type>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
In permimssions selector, all the groups are displayed. This discloses information, like hidden spaces, technical groups, ...

This fix adds a filter on UserACL to display only the groups authorized for the given user.