### PR TITLE
PLF-6637 : do not use SpacesAdministrationService component since it does not exist in 5.1

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPlugin.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPlugin.java
@@ -24,11 +24,8 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.core.space.SpacesAdministrationService;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of GroupVisibilityPlugin for space creation which allows to
@@ -46,13 +43,8 @@ public class SpaceCreationInvitationGroupVisibilityPlugin extends GroupVisibilit
 
   private UserACL                     userACL;
 
-  private SpacesAdministrationService spacesAdministrationService;
-
-  private List<String>                spacesAdministratorsGroups;
-
-  public SpaceCreationInvitationGroupVisibilityPlugin(UserACL userACL, SpacesAdministrationService spacesAdministrationService) {
+  public SpaceCreationInvitationGroupVisibilityPlugin(UserACL userACL) {
     this.userACL = userACL;
-    this.spacesAdministrationService = spacesAdministrationService;
   }
 
   @Override
@@ -65,17 +57,10 @@ public class SpaceCreationInvitationGroupVisibilityPlugin extends GroupVisibilit
     }
 
     Collection<MembershipEntry> userMemberships = userIdentity.getMemberships();
-    if (spacesAdministratorsGroups == null) {
-      spacesAdministratorsGroups = spacesAdministrationService.getSpacesAdministratorsMemberships()
-                                                              .stream()
-                                                              .map(membershipEntry -> membershipEntry.getGroup())
-                                                              .collect(Collectors.toList());
-    }
     return userMemberships.stream()
                           .anyMatch(userMembership -> ((group.getId().startsWith("/spaces/")
                               || group.getId().equals("/spaces"))
-                              && (spacesAdministratorsGroups.contains(userMembership.getGroup())
-                                  || userMembership.getGroup().equals(group.getId())
+                              && (userMembership.getGroup().equals(group.getId())
                                   || userMembership.getGroup().startsWith(group.getId() + "/")))
                               || ((userMembership.getGroup().equals(group.getId())
                                   || userMembership.getGroup().startsWith(group.getId() + "/"))

--- a/component/webui/src/test/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPluginTest.java
+++ b/component/webui/src/test/java/org/exoplatform/social/webui/SpaceCreationInvitationGroupVisibilityPluginTest.java
@@ -6,7 +6,6 @@ import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.impl.GroupImpl;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.social.core.space.SpacesAdministrationService;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -21,10 +20,7 @@ public class SpaceCreationInvitationGroupVisibilityPluginTest {
     // Given
     UserACL userACL = mock(UserACL.class);
     when(userACL.getSuperUser()).thenReturn("john");
-    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
-    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
-                                                                                                                        "*")));
-    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
+    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL);
 
     Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/users", "manager")));
     Group groupPlatform = new GroupImpl();
@@ -42,48 +38,12 @@ public class SpaceCreationInvitationGroupVisibilityPluginTest {
   }
 
   @Test
-  public void shouldHasPermissionOnSpacesGroupsWhenUserIsSpaceAdministrator() {
-    // Given
-    UserACL userACL = mock(UserACL.class);
-    when(userACL.getSuperUser()).thenReturn("root");
-    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
-    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
-                                                                                                                        "*")));
-    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
-
-    Identity userIdentity = new Identity("john", Arrays.asList(new MembershipEntry("/platform/spacesadmins", "manager")));
-    Group groupSpaces = new GroupImpl();
-    groupSpaces.setId("/spaces");
-    Group groupSpacesMarketing = new GroupImpl();
-    groupSpacesMarketing.setId("/spaces/marketing");
-    Group groupSpacesSales = new GroupImpl();
-    groupSpacesSales.setId("/spaces/sales");
-    Group groupSpacesEngineering = new GroupImpl();
-    groupSpacesEngineering.setId("/spaces/engineering");
-
-    // When
-    boolean hasPermissionOnSpaces = plugin.hasPermission(userIdentity, groupSpaces);
-    boolean hasPermissionOnSpacesMarketing = plugin.hasPermission(userIdentity, groupSpacesMarketing);
-    boolean hasPermissionOnSpacesSales = plugin.hasPermission(userIdentity, groupSpacesSales);
-    boolean hasPermissionOnSpacesEngineering = plugin.hasPermission(userIdentity, groupSpacesEngineering);
-
-    // Then
-    assertTrue(hasPermissionOnSpaces);
-    assertTrue(hasPermissionOnSpacesMarketing);
-    assertTrue(hasPermissionOnSpacesSales);
-    assertTrue(hasPermissionOnSpacesEngineering);
-  }
-
-  @Test
   public void shouldHasPermissionWhenUserIsInGivenGroup() {
     // Given
     UserACL userACL = mock(UserACL.class);
     when(userACL.getSuperUser()).thenReturn("root");
     when(userACL.getAdminGroups()).thenReturn("/platform/administrators");
-    SpacesAdministrationService spacesAdministrationService = mock(SpacesAdministrationService.class);
-    when(spacesAdministrationService.getSpacesAdministratorsMemberships()).thenReturn(Arrays.asList(new MembershipEntry("/platform/spacesadmins",
-                                                                                                                        "*")));
-    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL, spacesAdministrationService);
+    GroupVisibilityPlugin plugin = new SpaceCreationInvitationGroupVisibilityPlugin(userACL);
 
     Identity userIdentity = new Identity("john",
                                          Arrays.asList(new MembershipEntry("/platform/developers", "manager"),


### PR DESCRIPTION
The fix for PLF-6637 uses the SpacesAdministrationService component to check if the user is a space administrator or not.
This component has been added in 5.2 and is therefore not available in 5.1.

This fix removes the use of the component SpacesAdministrationService, so the new rule for group selector in space creation is: can only see the groups of the spaces where he is member.