### PR TITLE
PLF-8590 Enhance CSRF check parameter in URL (#590)

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/notification/IntranetNotification.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/notification/IntranetNotification.js
@@ -163,7 +163,7 @@
       },
       appendCSRFToken : function(url) {
         url.indexOf('?') >= 0 ? url += '&' : url += '?';
-        url += 'gtn:csrf=' + eXo.env.portal.csrfToken;
+        url += 'portal:csrf=' + eXo.env.portal.csrfToken;
         return url;
       }
   };


### PR DESCRIPTION
This modification applies new CSRF parameter naming that will avoid confusion made with '&gtn:csrf' that is converted into '>n:csrf' in some conditions