### PR TITLE
SOC-6232 : Wrong notification content when react to activity after me…

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -105,6 +105,17 @@ public interface ActivityManager {
   void updateActivity(ExoSocialActivity activity);
 
   /**
+   * Updates an existing activity.
+   *
+   * @param activity The activity to be updated.
+   * @param broadcast If the broadcast value is true , then the ActivityManager
+   *     should broadcast the event to all the listener that register on event updateActivity
+   *     *          user event listener will be called in the createUser method.
+   * @LevelAPI Platform
+   */
+  void updateActivity(ExoSocialActivity activity, boolean broadcast);
+
+  /**
    * Deletes a specific activity.
    *
    * @param activity The activity to be deleted.

--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManagerImpl.java
@@ -412,10 +412,20 @@ public class ActivityManagerImpl implements ActivityManager {
     return activityStorage.getSubComments(comment);
   }
 
+
+
   /**
    * {@inheritDoc}
    */
   public void updateActivity(ExoSocialActivity existingActivity) {
+    //by default, event is broadcasted
+    updateActivity(existingActivity,true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void updateActivity(ExoSocialActivity existingActivity, boolean broadcast) {
     String activityId = existingActivity.getId();
 
     // In order to get the added mentions in the ActivityMentionPlugin we need to
@@ -431,7 +441,9 @@ public class ActivityManagerImpl implements ActivityManager {
 
       existingActivity.setTemplateParams(mentionsTemplateParams);
     }
-    activityLifeCycle.updateActivity(existingActivity);
+    if (broadcast) {
+      activityLifeCycle.updateActivity(existingActivity);
+    }
   }
 
   /**
@@ -531,7 +543,8 @@ public class ActivityManagerImpl implements ActivityManager {
     }
     identityIds = (String[]) ArrayUtils.add(identityIds, identity.getId());
     existingActivity.setLikeIdentityIds(identityIds);
-    updateActivity(existingActivity);
+    //broadcast is false : we don't want to launch update listeners for a like
+    updateActivity(existingActivity, false);
     if(existingActivity.isComment()){
       activityLifeCycle.likeComment(existingActivity);
     } else {
@@ -550,7 +563,8 @@ public class ActivityManagerImpl implements ActivityManager {
     if (ArrayUtils.contains(identityIds, identity.getId())) {
       identityIds = (String[]) ArrayUtils.removeElement(identityIds, identity.getId());
       activity.setLikeIdentityIds(identityIds);
-      updateActivity(activity);
+      //broadcast is false : we don't want to launch update listeners for a like
+      updateActivity(activity, false);
     } else {
       LOG.warn("activity is not liked by identity: " + identity);
     }


### PR DESCRIPTION
…ntion user

Prior to this change, a notification can be sent, saying "An activity was updated" when a user like an activity.
This is due to the fact that ActivityManager.updateActivity is called in saveLike and deleteLike. So, updateActivity listeners are launched
This change add a broadcast parameter in updateActivity, to be able to update an activity without broadcasting the event.