### PR TITLE
fix/PLF-8604:A JS error is logged when commenting on Activity

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
@@ -70,7 +70,15 @@
       commentButton.click(function(event) {
         var commentId = commentButton.data("comment-id");
         var clickAction = commentButton.data("click").replace("COMMENTID", (commentId ? commentId : ""));
+        var currentComposerComment = 'CommentTextarea' + UIActivity.activityId;
         eval(clickAction);
+          try {
+              if (CKEDITOR.instances[currentComposerComment]) {
+                  CKEDITOR.instances[currentComposerComment].destroy(true);
+              }
+          } catch (e) {
+              console.log(e);
+          }
       });
     },
 
@@ -403,7 +411,16 @@
                        event.stopPropagation();
                        var commentId = editCommentButton.data("edit-comment-id");
                        var clickAction = editCommentButton.data("click").replace("COMMENTID", (commentId ? commentId : ""));
+                       var currentComposerEditComment = 'composerEditComment' + commentId;
                        eval(clickAction);
+                         try {
+                             if (CKEDITOR.instances[currentComposerEditComment]) {
+                                 CKEDITOR.instances[currentComposerEditComment].destroy();
+                             }
+                         } catch (e) {
+                             console.log(e);
+                         }
+
                      });
 
 


### PR DESCRIPTION
When we edit an existing comment, an JS error is logged in navigator caused by the call of the first ckeditor instance when we create a comment. So we need to remove the first instance by calling the method `destroy` in creation of comment and when editing the comment.