### PR TITLE
SOC-6232 : Wrong notification content when react to activity after mention user.

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -105,6 +105,17 @@ public interface ActivityManager {
   void updateActivity(ExoSocialActivity activity);
 
   /**
+   * Updates an existing activity.
+   *
+   * @param activity The activity to be updated.
+   * @param broadcast If the broadcast value is true , then the ActivityManager
+   *     should broadcast the event to all the listener that register on event updateActivity
+   *     *          user event listener will be called in the createUser method.
+   * @LevelAPI Platform
+   */
+  void updateActivity(ExoSocialActivity activity, boolean broadcast);
+
+  /**
    * Deletes a specific activity.
    *
    * @param activity The activity to be deleted.

--- a/component/notification/src/test/java/org/exoplatform/social/notification/web/template/EditCommentWebBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/web/template/EditCommentWebBuilderTest.java
@@ -79,7 +79,7 @@ public class EditCommentWebBuilderTest extends AbstractPluginTest {
         ctx.setNotificationInfo(editNotification.setTo("root"));
         MessageInfo info = buildMessageInfo(ctx);
         assertBody(info, "edited comment");
-        assertBody(info, "data-link=\"/portal/classic/activity?id=" + activity.getId() + "#comment-comment69\"");
+        assertBody(info, "data-link=\"/portal/classic/activity?id=" + activity.getId() + "#comment-comment72\"");
     }
 
 }


### PR DESCRIPTION
Prior to this change, a notification can be sent, saying "An activity was updated" when a user like an activity.
This is due to the fact that ActivityManager.updateActivity is called in saveLike and deleteLike. So, updateActivity listeners are launched
This change add a broadcast parameter in updateActivity, to be able to update an activity without broadcasting the event.