### PR TITLE
SOC-6232 : set the new method in the API with a default implementation to avoid breaking the API

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/manager/ActivityManager.java
@@ -113,7 +113,9 @@ public interface ActivityManager {
    *     *          user event listener will be called in the createUser method.
    * @LevelAPI Platform
    */
-  void updateActivity(ExoSocialActivity activity, boolean broadcast);
+  default void updateActivity(ExoSocialActivity activity, boolean broadcast) {
+    this.updateActivity(activity);
+  }
 
   /**
    * Deletes a specific activity.


### PR DESCRIPTION
The new method updateActivity added recently in the ActivityManager interface breaks the API.

In order to avoid breaking the API and making the upgrades more transparent, this fix set the new method with a default impementation.