### PR TITLE
PLF-8746 : Perf problem when reading commentsId from an activity with…

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImpl.java
@@ -142,7 +142,7 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
     List<String> replyToIds = new ArrayList<>();
     List<ActivityEntity> comments = activityEntity.getComments() != null ? activityEntity.getComments()
                                                                          : new ArrayList<>();
-    fillCommentsIdsAndPosters(comments, commentPosterIds, replyToIds, false);
+    fillCommentsIdsAndPosters(activityEntity, commentPosterIds, replyToIds, false);
     activity.setCommentedIds(commentPosterIds.toArray(new String[commentPosterIds.size()]));
     activity.setReplyToId(replyToIds.toArray(new String[replyToIds.size()]));
     activity.setMentionedIds(activityEntity.getMentionerIds().toArray(new String[activityEntity.getMentionerIds().size()]));
@@ -150,13 +150,12 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
     return activity;
   }
 
-  private void fillCommentsIdsAndPosters(List<ActivityEntity> comments,
+  private void fillCommentsIdsAndPosters(ActivityEntity activity,
                                          List<String> commentPosterIds,
                                          List<String> replyToIds,
                                          boolean isSubComment) {
-    if (comments == null || comments.isEmpty()) {
-      return;
-    }
+    
+    List<ActivityEntity> comments = activityDAO.findCommentsAndSubCommentOfActivity(activity.getId());
     List<Long> commentIds = new ArrayList<>();
     for (ActivityEntity comment : comments) {
       if (!commentPosterIds.contains(comment.getPosterId())) {
@@ -164,10 +163,6 @@ public class RDBMSActivityStorageImpl implements ActivityStorage {
       }
       replyToIds.add(getExoCommentID(comment.getId()));
       commentIds.add(comment.getId());
-    }
-    if (!isSubComment) {
-      List<ActivityEntity> subComments = activityDAO.findCommentsOfActivities(commentIds);
-      fillCommentsIdsAndPosters(subComments, commentPosterIds, replyToIds, true);
     }
   }
 

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/ActivityDAO.java
@@ -437,8 +437,16 @@ public interface ActivityDAO extends GenericDAO<ActivityEntity, Long> {
    * @return
    */
   List<ActivityEntity> findCommentsOfActivities(List<Long> ids);
-
-
+  
+  /**
+   * find comments and Sub Comments of some activity
+   *
+   * @param activityId
+   * @return
+   */
+  List<ActivityEntity> findCommentsAndSubCommentOfActivity(Long activityId);
+  
+  
   /**
    * Get list of activities switch list of IDs
    * 

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/ActivityDAOImpl.java
@@ -753,6 +753,14 @@ public class ActivityDAOImpl extends GenericDAOJPAImpl<ActivityEntity, Long> imp
     query.setParameter("ids", ids);
     return query.getResultList();
   }
+  
+  @Override
+  public List<ActivityEntity> findCommentsAndSubCommentOfActivity(Long activityId) {
+    TypedQuery<ActivityEntity> query = getEntityManager().createNamedQuery("SocActivity.findCommentsAndSubCommentOfActivity",
+                                                                           ActivityEntity.class);
+    query.setParameter("activityId", activityId);
+    return query.getResultList();
+  }
 
   @Override
   public List<ActivityEntity> getComments(long activityId, int offset, int limit) {

--- a/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/jpa/storage/entity/ActivityEntity.java
@@ -48,6 +48,8 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         @NamedQuery(name = "SocActivity.findCommentsOfActivities", query = "SELECT a FROM SocActivity a "
             + " WHERE a.parent.id IN (:ids) "
             + " ORDER BY a.posted ASC"),
+        @NamedQuery(name = "SocActivity.findCommentsAndSubCommentOfActivity", query = "SELECT a FROM SocActivity a "
+        + " WHERE a.parent.id = :activityId OR a.parent.parent.id = :activityId ORDER BY a.posted ASC"),
         @NamedQuery(name = "SocActivity.numberCommentsOfActivity", query = "SELECT count(distinct a.id) FROM SocActivity a WHERE a.parent.id = :activityId"),
         @NamedQuery(name = "SocActivity.findNewerCommentsOfActivity",
                 query = "SELECT a FROM SocActivity a WHERE a.parent.id = :activityId AND a.updatedDate > :sinceTime ORDER BY a.updatedDate ASC"),

--- a/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
@@ -717,6 +717,20 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
     assertEquals(2, got.getReplyToId().length);
     assertEquals(2, got.getCommentedIds().length);
     assertEquals(2, got.getMentionedIds().length);
+  
+  
+    ExoSocialActivity subComment1 = new ExoSocialActivityImpl();
+    subComment1.setTitle("subcomment 1");
+    subComment1.setUserId(maryIdentity.getId());
+    subComment1.setParentCommentId(comment1.getId());
+    activityStorage.saveComment(activity, subComment1);
+    got = activityStorage.getActivity(activity.getId());
+    
+    assertEquals(3, got.getReplyToId().length);
+    assertEquals(3, got.getCommentedIds().length);
+    assertEquals(2, got.getMentionedIds().length);
+    
+    
   }
 
   @MaxQueryNumber(57)


### PR DESCRIPTION
… a lot of comments

When getting commentId for an activity, we make 2 queries
- 1 to get comments from first level (activities where parentId = activityId)
- 1 to get subcomment (activities where parentId in (commentsId))

If an activity have a lot of comments (like space activity : all comments are member join)
the commentIds list can be huge.

When we make large user add in space, this particular request (with IN) is cached in SessionFactoryImpl.cacheQueryPlan. Each request with different list of id is one entry in cache.
In some case, it can fill the JVM memory.

We replace theses 2 requests by only one : we search activity where parentId=activityId of where parent.parentId=activityId
We search comments and subComments in one request, which can be cached once in cacheQueryPlan.