### PR TITLE
Fix/space groups binding inactive users (#139)

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingMembershipGroupEventListener.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/binding/listener/SpaceBindingMembershipGroupEventListener.java
@@ -29,6 +29,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.MembershipEventListener;
 import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.UserStatus;
 import org.exoplatform.social.core.binding.model.GroupSpaceBinding;
 import org.exoplatform.social.core.binding.model.GroupSpaceBindingReportAction;
 import org.exoplatform.social.core.binding.model.UserSpaceBinding;
@@ -52,7 +53,7 @@ public class SpaceBindingMembershipGroupEventListener extends MembershipEventLis
     if (isNew && !isASpaceGroup(groupId)) {
       RequestLifeCycle.begin(PortalContainer.getInstance());
       try {
-        if (isUserNewMemberToGroup(userName, groupId)) {
+        if (isActive(userName) && isUserNewMemberToGroup(userName, groupId)) {
           groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
           spaceService = CommonsUtils.getService(SpaceService.class);
 
@@ -107,7 +108,12 @@ public class SpaceBindingMembershipGroupEventListener extends MembershipEventLis
       }
     }
   }
-
+  
+  private boolean isActive(String userName) throws Exception {
+    organizationService = CommonsUtils.getOrganizationService();
+    return organizationService.getUserHandler().findUserByName(userName, UserStatus.ENABLED) != null;
+  }
+  
   @Override
   public void postDelete(Membership m) throws Exception {
     String userName = m.getUserName();
@@ -115,7 +121,7 @@ public class SpaceBindingMembershipGroupEventListener extends MembershipEventLis
     if (!isASpaceGroup(groupId)) {
       RequestLifeCycle.begin(PortalContainer.getInstance());
       try {
-        if (isUserNoMoreMemberOfGroup(userName, groupId)) {
+        if (isActive(userName) && isUserNoMoreMemberOfGroup(userName, groupId)) {
           groupSpaceBindingService = CommonsUtils.getService(GroupSpaceBindingService.class);
           spaceService = CommonsUtils.getService(SpaceService.class);
           // Retrieve removed user's all bindings.

--- a/webapp/vue-portlet/src/main/webapp/spaces-administration-app/components/ExoSpacesAdministrationSpaces.vue
+++ b/webapp/vue-portlet/src/main/webapp/spaces-administration-app/components/ExoSpacesAdministrationSpaces.vue
@@ -62,7 +62,7 @@ export default {
   mounted() {
     const windowLocationHash = window.location.hash;
     if (windowLocationHash === '#bindingReports') {
-      this.activeTab = 3;
+      this.activeTab = 5;
     } else if (windowLocationHash === '#permissions') {
       this.activeTab = 2;
     } else {


### PR DESCRIPTION
* When a user is deactivated, there are problems with groupBinding

This change make a user deactivated as a removed user for the group binding feature :
when he is added or removed in a group, groupBinding do nothing
when he is deactivated, groupBinding remove all his bindings
When he is reactivated, groupBinding recreate all possible bindings