### PR TITLE
MAINT-24653: Allow space editors to be invited to the spaces instead of set directly as members

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/space/impl/SpaceServiceImpl.java
@@ -390,13 +390,7 @@ public class SpaceServiceImpl implements SpaceService {
       userIds.remove(creator);
       for (String userId : userIds) {
         String[] invitedUsers = space.getInvitedUsers();
-        if (isSuperManager(userId)) {
-          members = space.getMembers();
-          if (!ArrayUtils.contains(members, userId)) {
-            members = (String[]) ArrayUtils.add(members, userId);
-            space.setMembers(members);
-          }
-        } else if (!ArrayUtils.contains(invitedUsers, userId)) {
+        if (!ArrayUtils.contains(invitedUsers, userId)) {
           invitedUsers = (String[]) ArrayUtils.add(invitedUsers, userId);
           inviteds.add(userId);
           space.setInvitedUsers(invitedUsers);

--- a/component/webui/src/main/java/org/exoplatform/social/webui/UIUserInvitation.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/UIUserInvitation.java
@@ -244,11 +244,6 @@ public class UIUserInvitation extends UIForm {
           for (int idx = 0; idx < invitedUsers.length; idx++) {
             name = invitedUsers[idx].trim();
             if (name.length() > 0) {
-              if (spaceService.isSuperManager(name)) {
-                spaceService.addMember(space, name);
-                continue;
-              }
-
               if (!usersForInviting.contains(name) && !spaceService.isMember(space, name)) {
                 usersForInviting.add(name);
               }


### PR DESCRIPTION
Currently the space editors are set directly as member when invited by the space manager, we need them to be really invited from both space settings members or space creation in order to allow them accept or deny the invitation.